### PR TITLE
Replace usage of deprecated Eigen class

### DIFF
--- a/include/pybind11/eigen.h
+++ b/include/pybind11/eigen.h
@@ -573,9 +573,9 @@ struct type_caster<Type, enable_if_t<is_eigen_sparse<Type>::value>> {
         if (!values || !innerIndices || !outerIndices)
             return false;
 
-        value = Eigen::MappedSparseMatrix<Scalar,
+        value = Eigen::Map<Eigen::SparseMatrix<Scalar,
                                           Type::Flags & (Eigen::RowMajor | Eigen::ColMajor),
-                                          StorageIndex>(
+                                          StorageIndex>>(
             shape[0].cast<Index>(), shape[1].cast<Index>(), nnz,
             outerIndices.mutable_data(), innerIndices.mutable_data(), values.mutable_data());
 


### PR DESCRIPTION
Replace usage of deprecated Eigen class MappedSparseMatrix.

<!--
Title (above): please place [branch_name] at the beginning if you are targeting a branch other than master. *Do not target stable*.
It is recommended to use conventional commit format, see conventionalcommits.org, but not required.
-->
## Description

Eigen::MappedSparseMatrix has been deprecated since Eigen 3.3 from 2016. Use the equivalent modern syntax Eigen::Map<Eigen::SparseMatrix<...>>.

<!-- Include relevant issues or PRs here, describe what changed and why -->


## Suggested changelog entry:

The deprecated class was removed on the Eigen master branch in:

https://gitlab.com/libeigen/eigen/-/commit/7e586635ba85ba926ba3148f8d14beca3535f970
